### PR TITLE
Update 2014-12-05-bang-patterns.lhs

### DIFF
--- a/posts/2014-12-05-bang-patterns.lhs
+++ b/posts/2014-12-05-bang-patterns.lhs
@@ -79,7 +79,7 @@ This function will now produce values only if `loud` evaluates to `True` or
 -> hello3 True
 "Hello."
 -> hello3 False
-"hello."
+"Hello."
 -> hello3 undefined
 *** Exception: Prelude.undefined
 -> hello3 (fix id)


### PR DESCRIPTION
Seems unlikely for `hello` to differ from `hello3` except in strictness
