### PR TITLE
Fix links to GHC guide

### DIFF
--- a/guest-posts/2014-12-06-rebindable-syntax.md
+++ b/guest-posts/2014-12-06-rebindable-syntax.md
@@ -19,7 +19,7 @@ import Data.Map as M
 ```
 
 Today we'll be talking about
-[`RebindableSyntax`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/syntax-extns.html#rebindable-syntax). `RebindableSyntax`
+[`RebindableSyntax`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#rebindable-syntax). `RebindableSyntax`
 allows you to rewrite your own versions of operators in the Prelude (with
 different types, even!). At first glance, this doesn't seem incredibly useful:
 Why would we want to rebind operators when we can just define new functions or

--- a/guest-posts/2014-12-22-template-haskell.md
+++ b/guest-posts/2014-12-22-template-haskell.md
@@ -204,7 +204,7 @@ quotations, called quasi-quotations.
   spaces. Though, all GHC is doing is determining which parser to use based on
   the context within the oxford brackets.[^7]
 
-    Quasi-quotations is a big second part to meta-programming. They're essentially what makes it possible to write DSLs. I'm not going to cover it here since this guide is pretty long as it is, but if you're interested, there are many guides to using quasi-quotations, find them [here](https://www.cs.drexel.edu/~mainland/publications/mainland07quasiquoting.pdf), [here](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/template-haskell.html#th-quasiquotation), and [here](https://www.fpcomplete.com/user/marcin/quasiquotation-101) (this one assumes you're familiar with Parsec parsing).
+    Quasi-quotations is a big second part to meta-programming. They're essentially what makes it possible to write DSLs. I'm not going to cover it here since this guide is pretty long as it is, but if you're interested, there are many guides to using quasi-quotations, find them [here](https://www.cs.drexel.edu/~mainland/publications/mainland07quasiquoting.pdf), [here](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#th-quasiquotation), and [here](https://www.fpcomplete.com/user/marcin/quasiquotation-101) (this one assumes you're familiar with Parsec parsing).
 
 
 An important restriction on Template Haskell to remember is _when inside a

--- a/posts/2014-12-02-view-patterns.md
+++ b/posts/2014-12-02-view-patterns.md
@@ -8,7 +8,7 @@ bindings - such as top-level function definitions, `where` clauses, and `let`
 bindings. Today, we'll begin by looking at a simple yet powerful extension -
 *view patterns*.
 
-[View patterns](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/syntax-extns.html#view-patterns)
+[View patterns](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#view-patterns)
 extend our ability to pattern match on variables by also allowing us to pattern
 match on the result of function application. To take a simple example, lets work
 with a `Map` from Haskell packages on Hackage, to the amount of downloads. To

--- a/posts/2014-12-04-record-wildcards.lhs
+++ b/posts/2014-12-04-record-wildcards.lhs
@@ -5,7 +5,7 @@ title: "24 Days of GHC Extensions: Record Wildcards"
 Occasionally, you come across a little trick or method for doing something that
 seems somewhat inconsequential - but rapidly becomes an indispensable item in
 your programming toolbox. For me, the
-[`RecordWildcards`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/syntax-extns.html#record-wildcards)
+[`RecordWildcards`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#record-wildcards)
 extension is a prime example of this scenario.
 
 > {-# LANGUAGE OverloadedStrings #-}

--- a/posts/2014-12-09-recursive-do.lhs
+++ b/posts/2014-12-09-recursive-do.lhs
@@ -103,7 +103,7 @@ similar. Infact, all we've had to do is replace the pure `let x = y` bindings
 with effectful `x <- y` bindings, and call out to our effectful
 function. Finally, the magic sauce at the top is to use a new piece of syntax
 `rec`. `rec` comes from the
-[RecursiveDo](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/syntax-extns.html#recursive-do-notation)
+[RecursiveDo](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#recursive-do-notation)
 extension, and while the details are beyond the scope of this post (there's a
 whole thesis on it!), we can see here that it serves the same purpose as forming
 recursive bindings, as we did with `let`.

--- a/posts/2014-12-10-nullary-type-classes.lhs
+++ b/posts/2014-12-10-nullary-type-classes.lhs
@@ -4,7 +4,7 @@ title: "24 Days of GHC Extensions: Nullary Type Classes"
 
 While I wait for a few more guest posts to soldify, I thought it might be fun to
 look at another new extension to GHC -
-[`NullaryTypeClasses`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/type-class-extensions.html#nullary-type-classes).
+[`NullaryTypeClasses`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#nullary-type-classes).
  
 > {-# LANGUAGE NullaryTypeClasses #-}
 

--- a/posts/2014-12-17-overloaded-strings.lhs
+++ b/posts/2014-12-17-overloaded-strings.lhs
@@ -27,7 +27,7 @@ is polymorphic over all `Fractional` instances.
 
 This polymorphism is extremely powerful, and it allows us to write embedded domain specific languages in Haskell source code, without having to introduce new constructs for otherwise normal values. So why should string literals be any different?
 
-The good news is - they don't have to be! If we enable the [overloaded strings](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/type-class-extensions.html#overloaded-strings), then string literals get a different type:
+The good news is - they don't have to be! If we enable the [overloaded strings](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#overloaded-strings), then string literals get a different type:
 
 ```
 .> :set -XOverloadedStrings


### PR DESCRIPTION
Using the command:
sed -i "s@https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/.*\.html#\(.*\))@https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts\.html#\1)@" *